### PR TITLE
Added GitHub mirror blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ And here is a list of awesome uBlacklist subscriptions.  Add uBlacklist to your 
 - [Edit](https://github.com/rjaus/ublacklist-pinterest/blob/main/ublacklist-pinterest.txt) - [Pinterest](https://raw.githubusercontent.com/rjaus/ublacklist-pinterest/main/ublacklist-pinterest.txt): Blocks all websites for pinterest.
 
 ## Developer Sites
+- [Edit](https://github.com/arosh/ublacklist-github-translation/blob/master/uBlacklist.txt) - [GitHub Translation splogs](https://raw.githubusercontent.com/arosh/ublacklist-github-translation/master/uBlacklist.txt): Blocks a bunch of low value GitHub translation spam blogs.
 - [Edit](https://github.com/arosh/ublacklist-stackoverflow-translation/blob/master/uBlacklist.txt) - [Stack Overflow Translation splogs](https://raw.githubusercontent.com/arosh/ublacklist-stackoverflow-translation/master/uBlacklist.txt): Blocks a bunch of low value stack overflow translation spam blogs.
 
 ## Local Business


### PR DESCRIPTION
Added list for blocking GitHub mirrors like GitMemory. This list is maintained by the same person who does the Stack Overflow translations list.