### PR TITLE
Add ai-content-blocklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ And here is a list of awesome uBlacklist subscriptions.  Add uBlacklist to your 
 
 ## Content Farms
 - [Edit](https://github.com/wdmpa/content-farm-list/blob/main/uBlacklist.txt) - [Generic content farm](https://raw.githubusercontent.com/wdmpa/content-farm-list/main/uBlacklist.txt): Blocks AI content farm.
+- [Edit](https://github.com/agsimmons/ai-content-blocklist/blob/main/uBlacklist.txt) - [AI Content Blocklist](https://raw.githubusercontent.com/agsimmons/ai-content-blocklist/refs/heads/main/uBlacklist.txt): Blocks AI generated news, answers, and more. This list does not block any discussion of AI or disclosed AI content.
 
 ## Gaming
 - [StopModReposts](https://api.stopmodreposts.org/ublacklist.txt): Blocks Multiple mod repost websites.


### PR DESCRIPTION
Hi, I've started a new blocklist for AI generated content. It doesn't have many domains included yet, but my hope is to get some contributors to start building it out.

The goal of the list is to include domains that deceptively display AI generated news, answers, blog posts, and more. I specifically am not including AI generated images or videos, discussion of AI, or AI generated content that is labeled as such.

I think this is a niche that isn't already represented on this list. The "Generic content farm" list is heavily focused on Chinese-language sources, and the "uBlockOrigin & uBlacklist Huge AI Blocklist" blocks any mention of AI or AI generated content even if disclosed.

Thanks