### PR TITLE
Add uBlacklistFandomWikis

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ And here is a list of awesome uBlacklist subscriptions.  Add uBlacklist to your 
 ## General
 
 - [Edit](https://github.com/popcar2/BadWebsiteBlocklist#contributing) - [BadWebsiteBlocklist](https://raw.githubusercontent.com/popcar2/BadWebsiteBlocklist/refs/heads/main/uBlacklist.txt): Blocks AI spam, low-effort SEO spam, misleading advertisements, and generally bad websites that shouldn't appear in search results.
+- [uBlacklistFandomWikis](https://git.32bit.cafe/nu/uBlacklistFandomWikis/raw/branch/main/ublacklist-fandom.txt): Blocks Fandom wikis from search results when a viable alternative exists


### PR DESCRIPTION
> A blocklist for uBlacklist that hides Fandom wikis from search results when an independent wiki or a wiki on another wiki farm site (i.e. Miraheze or atwiki) is available instead, or other equivalent non-wiki sites where applicable. Exceptions are if the Fandom wiki is the only wiki of proper quality.

<https://git.32bit.cafe/nu/uBlacklistFandomWikis>

I wasn't sure if this qualified as Social Media or Content Farm, so I stuck it in General like a coward.