### PR TITLE
Add watermark-blacklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,4 @@ And here is a list of awesome uBlacklist subscriptions.  Add uBlacklist to your 
 ## General
 
 - [Edit](https://github.com/popcar2/BadWebsiteBlocklist#contributing) - [BadWebsiteBlocklist](https://raw.githubusercontent.com/popcar2/BadWebsiteBlocklist/refs/heads/main/uBlacklist.txt): Blocks AI spam, low-effort SEO spam, misleading advertisements, and generally bad websites that shouldn't appear in search results.
+- [Edit](https://github.com/pnppl/watermark-blacklist/blob/master/uBlacklist.txt) - [watermark-blacklist](https://raw.githubusercontent.com/pnppl/watermark-blacklist/refs/heads/master/uBlacklist.txt): Blocks sites that host watermarked images.


### PR DESCRIPTION
This is a new list I made. It blocks domains that host a bunch of watermarked images, ie proprietary stock websites, with the aim of cleaning up image search results. 

I have no idea if anyone else would be interested in this, but your list of lists is how I found things to subscribe to, so I figured it wouldn't hurt to share. I put it under General.

Sorry if I screwed anything up with the PRs, btw. I don't use git or Github very often.

<https://github.com/pnppl/watermark-blacklist>